### PR TITLE
Fix bootstrap class on buttons

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -17,7 +17,7 @@
 
  .container {
    background-color: #f6fbfc;
-   padding-bottom: 60px;
+   padding-bottom: 70px;
  }
 footer {
   background-color: #ccc;

--- a/app/views/articles/_form.html.erb
+++ b/app/views/articles/_form.html.erb
@@ -30,7 +30,7 @@
   </p>
 
   <p>
-    <%= form.submit class: 'btn btn-outline-primary' %>
+    <%= form.submit class: 'btn btn-primary' %>
   </p>
 
 <% end %>

--- a/app/views/articles/edit.html.erb
+++ b/app/views/articles/edit.html.erb
@@ -3,5 +3,5 @@
 
 <%= render 'form' %>
 
-<%= link_to 'Back', articles_path, class: 'btn btn-outline-primary' %>
+<%= link_to 'Back', articles_path, class: 'btn btn-primary' %>
 </div>

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -11,18 +11,18 @@
     <tr scope="row">
       <td><%= article.title %></td>
       <td><%= article.author %></td>
-      <td><%= link_to 'View', article, class: 'btn btn-outline-default' %></td>
-      <td><%= link_to 'Edit', edit_article_path(article), class: 'btn btn-outline-default' %></td>
+      <td><%= link_to 'View', article, class: 'btn btn-default' %></td>
+      <td><%= link_to 'Edit', edit_article_path(article), class: 'btn btn-default' %></td>
       <td><%= link_to 'Delete',
         article_path(article),
               method: :delete,
-              data: { confirm: 'Are you sure?' }, class: 'btn btn-outline-default' %>
+              data: { confirm: 'Are you sure?' }, class: 'btn btn-default' %>
       </td>
     </tr>
   <% end %>
 </table>
 
 <br>
-<%= link_to 'New article', new_article_path, class: 'btn btn-outline-primary' %>
-<%= link_to 'Home', home_path, class: 'btn btn-outline-primary' %>
+<%= link_to 'New article', new_article_path, class: 'btn btn-primary' %>
+<%= link_to 'Home', home_path, class: 'btn btn-primary' %>
 </div>

--- a/app/views/articles/new.html.erb
+++ b/app/views/articles/new.html.erb
@@ -3,5 +3,5 @@
 
 <%= render 'form' %>
 
-<%= link_to 'Back', articles_path, class: 'btn btn-outline-primary' %>
+<%= link_to 'Back', articles_path, class: 'btn btn-primary' %>
 </div>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -20,8 +20,8 @@
 <h2>Add a comment:</h2>
 <%= render 'comments/form' %>
 
-  <%= link_to 'Edit', edit_article_path(@article),  class: 'btn btn-outline-primary' %>
+  <%= link_to 'Edit', edit_article_path(@article),  class: 'btn btn-default' %>
 
 
-<%= link_to 'All Articles', articles_path, class: 'btn btn-outline-primary' %>
+<%= link_to 'All Articles', articles_path, class: 'btn btn-primary' %>
 </div>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -8,6 +8,6 @@
     <%= form.text_area :body %>
   </p>
   <p>
-    <%= form.submit class: 'btn btn-outline-primary' %>
+    <%= form.submit class: 'btn btn-default' %>
   </p>
 <% end %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -9,7 +9,7 @@
     <%= label_tag :password %><br />
     <%= password_field_tag :password %>
   </div><br>
-  <div class="actions"><%= submit_tag "Log In", class: 'btn btn-outline-primary' %></div>
+  <div class="actions"><%= submit_tag "Log In", class: 'btn btn-primary' %></div>
 <% end %><br>
-<%= link_to 'Home', home_path, class: 'btn btn-outline-primary' %>
+<%= link_to 'Home', home_path, class: 'btn btn-primary' %>
 </div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -25,5 +25,5 @@
   </tbody>
 </table>
 <br>
-<%= link_to 'Home', home_path, class: 'btn btn-outline-primary' %>
+<%= link_to 'Home', home_path, class: 'btn btn-primary' %>
 </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -26,7 +26,7 @@
     <%= f.label :password_confirmation %><br />
     <%= f.password_field :password_confirmation %>
   </div><br>
-  <div class="actions"><%= f.submit "Sign Up", class: 'btn btn-outline-primary' %></div>
+  <div class="actions"><%= f.submit "Sign Up", class: 'btn btn-primary' %></div>
 <% end %><br>
-<%= link_to 'Home', home_path, class: 'btn btn-outline-primary' %>
+<%= link_to 'Home', home_path, class: 'btn btn-primary' %>
 </div>


### PR DESCRIPTION
- `btn btn-outline-primary` works for Bootstrap version 4
- Current version of bootstrap-sass is `3.3.6`
- Styled button class with `btn btn-primary` and `btn btn-default`